### PR TITLE
spring-boot-watch-pipeline-activity to 1.0.0

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,4 +1,7 @@
 dependencies:
+- name: demo81
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.2
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.build.cd.jenkins-x.io
@@ -7,6 +10,6 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.build.cd.jenkins-x.io
   version: 2.3.58
-- name: demo81
+- name: spring-boot-watch-pipeline-activity
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.2
+  version: 1.0.0


### PR DESCRIPTION
Promote spring-boot-watch-pipeline-activity to version 1.0.0